### PR TITLE
docs(schema): add RTMP egress fields to session configuration

### DIFF
--- a/session-configuration-schema.yaml
+++ b/session-configuration-schema.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Aperture Live Session Configuration API
   version: 1.0.0
-  description: Schema for session configuration used in WHIP streaming sessions
+  description: Schema for session configuration used in WHIP (WebRTC) and RTMP streaming sessions
 
 components:
   schemas:
@@ -67,6 +67,24 @@ components:
         locationHref:
           type: string
           description: Location reference URL
+        rtmpURL:
+          type: string
+          format: uri
+          nullable: true
+          description: >-
+            RTMP ingest URL for RTMP egress to platforms that only accept RTMP
+            (e.g. YouTube, Twitch, custom). When present and non-empty, the
+            session streams via RTMP instead of WHIP/WebRTC; the transport is
+            inferred from the presence of this field. The top-level `whip` URL
+            is ignored for RTMP sessions.
+          example: "rtmp://live.example.com/app"
+        rtmpStreamKey:
+          type: string
+          nullable: true
+          description: >-
+            RTMP stream key appended to the publish request. Optional; may be
+            omitted or empty when the key is embedded in `rtmpURL`.
+          example: "sk-test-123"
         ecs:
           $ref: '#/components/schemas/ECS'
 


### PR DESCRIPTION
## Summary

Adds the RTMP egress fields to `session-configuration-schema.yaml` so the public schema documents how RTMP streaming is configured (corresponds to the RTMP egress support added to the app in aperture-live-ios).

Two new optional fields under `metadata`:

| Field | Wire location | Notes |
|-------|---------------|-------|
| `rtmpURL` | `metadata.rtmpURL` | RTMP ingest URL. When present and non-empty, the session streams via **RTMP** instead of WHIP/WebRTC. Transport is **inferred** from the presence of this field. |
| `rtmpStreamKey` | `metadata.rtmpStreamKey` | Optional stream key appended to the publish request. |

There is no explicit `transport` field in the wire payload — the app picks RTMP automatically when `rtmpURL` is supplied, otherwise defaults to WHIP. The top-level `whip` URL is ignored for RTMP sessions.

Also updated the API description to mention both WHIP and RTMP.

## Test plan
- [x] `yaml.safe_load` parses the document without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)